### PR TITLE
Give Gnome 42 Console the terminal icon

### DIFF
--- a/links/scalable/apps/org.gnome.Console.svg
+++ b/links/scalable/apps/org.gnome.Console.svg
@@ -1,0 +1,1 @@
+terminal.svg

--- a/links/symbolic/apps/org.gnome.Console-symbolic.svg
+++ b/links/symbolic/apps/org.gnome.Console-symbolic.svg
@@ -1,0 +1,1 @@
+terminal-app-symbolic.svg


### PR DESCRIPTION
I just installed the Gnome 42 Console, as opposed to the Gnome Terminal from earlier versions and saw that there wasn't an icon associated from this repository. This pull request adds it.