### PR TITLE
Fix several symbolic links

### DIFF
--- a/links/22/devices/uav.svg
+++ b/links/22/devices/uav.svg
@@ -1,1 +1,0 @@
-uav-quadcopter.svg

--- a/links/24/devices/uav.svg
+++ b/links/24/devices/uav.svg
@@ -1,1 +1,0 @@
-uav-quadcopter.svg

--- a/links/24/panel/org.xfce.panel.showdesktop.svg
+++ b/links/24/panel/org.xfce.panel.showdesktop.svg
@@ -1,1 +1,0 @@
-user-desktop.svg

--- a/links/24/panel/org.xfce.xfdesktop.svg
+++ b/links/24/panel/org.xfce.xfdesktop.svg
@@ -1,1 +1,0 @@
-user-desktop.svg

--- a/links/scalable/apps/libre-cad.svg
+++ b/links/scalable/apps/libre-cad.svg
@@ -1,1 +1,1 @@
-/Tela-circle-icon-theme/src/scalable/apps/librecad.svg
+librecad.svg

--- a/links/scalable/apps/pcb-new.svg
+++ b/links/scalable/apps/pcb-new.svg
@@ -1,1 +1,1 @@
-.../Tela-circle-icon-theme/src/scalable/apps/pcbnew.svg
+pcbnew.svg

--- a/links/scalable/apps/steam_icon_1486350.svg
+++ b/links/scalable/apps/steam_icon_1486350.svg
@@ -1,1 +1,1 @@
-src/scalable/apps/vroid-studio.svg
+vroid-studio.svg


### PR DESCRIPTION
There are several symbolic links that are broken or bad created:
```
tela-circle-icon-theme E: Symlink (usr/share/icons/Tela-circle-yellow-dark/22/devices/uav.svg) points to non-existing uav-quadcopter.svg
tela-circle-icon-theme E: Symlink (usr/share/icons/Tela-circle-yellow-dark/24/devices/uav.svg) points to non-existing uav-quadcopter.svg
tela-circle-icon-theme E: Symlink (usr/share/icons/Tela-circle-yellow/22/devices/uav.svg) points to non-existing uav-quadcopter.svg
tela-circle-icon-theme E: Symlink (usr/share/icons/Tela-circle-yellow/24/devices/uav.svg) points to non-existing uav-quadcopter.svg
tela-circle-icon-theme E: Symlink (usr/share/icons/Tela-circle-yellow/24/panel/org.xfce.panel.showdesktop.svg) points to non-existing user-desktop.svg
tela-circle-icon-theme E: Symlink (usr/share/icons/Tela-circle-yellow/24/panel/org.xfce.xfdesktop.svg) points to non-existing user-desktop.svg
tela-circle-icon-theme E: Symlink (usr/share/icons/Tela-circle-yellow/scalable/apps/libre-cad.svg) points to non-existing /Tela-circle-icon-theme/src/scalable/apps/librecad.svg
tela-circle-icon-theme E: Symlink (usr/share/icons/Tela-circle-yellow/scalable/apps/pcb-new.svg) points to non-existing .../Tela-circle-icon-theme/src/scalable/apps/pcbnew.svg
tela-circle-icon-theme E: Symlink (usr/share/icons/Tela-circle-yellow/scalable/apps/steam_icon_1486350.svg) points to non-existing src/scalable/apps/vroid-studio.svg
```
This merge request fix all