### PR TITLE
Fix several symbolic links

### DIFF
--- a/links/22/devices/uav.svg
+++ b/links/22/devices/uav.svg
@@ -1,1 +1,0 @@
-uav-quadcopter.svg

--- a/links/24/devices/uav.svg
+++ b/links/24/devices/uav.svg
@@ -1,1 +1,0 @@
-uav-quadcopter.svg

--- a/links/24/panel/org.xfce.panel.showdesktop.svg
+++ b/links/24/panel/org.xfce.panel.showdesktop.svg
@@ -1,1 +1,0 @@
-user-desktop.svg

--- a/links/24/panel/org.xfce.xfdesktop.svg
+++ b/links/24/panel/org.xfce.xfdesktop.svg
@@ -1,1 +1,0 @@
-user-desktop.svg

--- a/links/scalable/apps/terminator.svg
+++ b/links/scalable/apps/terminator.svg
@@ -1,1 +1,0 @@
-terminal.svg


### PR DESCRIPTION
MR #134 introduced a series of symbolic links that point to files that do not exist:
```
tela-circle-icon-theme-standard-git E: Symlink (usr/share/icons/Tela-circle/22/devices/uav.svg) points to non-existing uav-quadcopter.svg
tela-circle-icon-theme-standard-git E: Symlink (usr/share/icons/Tela-circle/24/devices/uav.svg) points to non-existing uav-quadcopter.svg
tela-circle-icon-theme-standard-git E: Symlink (usr/share/icons/Tela-circle/24/panel/org.xfce.panel.showdesktop.svg) points to non-existing user-desktop.svg
tela-circle-icon-theme-standard-git E: Symlink (usr/share/icons/Tela-circle/24/panel/org.xfce.xfdesktop.svg) points to non-existing user-desktop.svg
```

This had already been resolved in #123 but it is possible that the fork that was merged in #134 was not fully updated.

In addition, the terminator symbolic link is removed since it has its own icon introduced in #122.