### PR TITLE
Update Zen Browser Flatpak App ID

### DIFF
--- a/links/scalable/apps/app.zen_browser.zen.svg
+++ b/links/scalable/apps/app.zen_browser.zen.svg
@@ -1,0 +1,1 @@
+zen-browser.svg


### PR DESCRIPTION
Hey @vinceliuice ,

So Zen Browser Team decided to change their Flatpak App ID from `io.github.zen_browser.zen` to `app.zen_browser.zen` in their latest version. 

This PR add link icon for their latest app id.