### PR TITLE
Symlink from `thunderbolt.svg` to `cs-thunderbolt.svg`.

### DIFF
--- a/links/scalable/apps/cs-thunderbolt.svg
+++ b/links/scalable/apps/cs-thunderbolt.svg
@@ -1,0 +1,1 @@
+thunderbolt.svg


### PR DESCRIPTION
Cinnamon 6.6 introduced new setting called "Thunderbolt" and it does not have an icon and falls back to vanilla one.