### PR TITLE
Remove `links/scalable/apps/edit-find.svg` to fix search icon in Audacious.

### DIFF
--- a/links/scalable/apps/edit-find.svg
+++ b/links/scalable/apps/edit-find.svg
@@ -1,1 +1,0 @@
-utilities-log-viewer.svg


### PR DESCRIPTION
Audacious uses this icon to display search icon, which is expected to be symbolic one, but in case with `links/scalable/apps/edit-find.svg` being linked to `src/scalable/apps/utilities-log-viewer.svg` - it is not symbolic, so it looks like that:
<img width="843" height="65" alt="2026-02-06_22-00-22" src="https://github.com/user-attachments/assets/a8ffe8b9-7bec-4c45-83f0-de00fd6257ac" />


After removing symlink:
<img width="844" height="68" alt="2026-02-06_22-02-37" src="https://github.com/user-attachments/assets/b9250ea0-6518-4053-b9ec-f411bc986d2c" />