### PR TITLE
Add org.mozilla.thunderbird.svg link for flatpak compatibility

### DIFF
--- a/links/scalable/apps/org.mozilla.thunderbird.svg
+++ b/links/scalable/apps/org.mozilla.thunderbird.svg
@@ -1,0 +1,1 @@
+thunderbird.svg


### PR DESCRIPTION
Mozilla Thunderbird icon wasn't being recognized by the flatpak application due to case sensitivity. Added org.mozilla.thunderbird.svg link for flatpak compatibility. 